### PR TITLE
Allow passing option overrides in getDefaultOptions

### DIFF
--- a/src/Facades/Qr.php
+++ b/src/Facades/Qr.php
@@ -25,9 +25,9 @@ class Qr extends Facade
         return 'qr';
     }
 
-    public static function getDefaultOptions(): array
+    public static function getDefaultOptions(array $options = []): array
     {
-        return [
+        return array_merge([
             'size' => '300',
             'type' => 'png',
             'margin' => '1',
@@ -48,7 +48,7 @@ class Qr extends Facade
                 'disk' => 'public',
                 'directory' => null,
             ],
-        ];
+        ], $options);
     }
 
     public static function getFormSchema(


### PR DESCRIPTION
Small change to allow you to pass an array of options to override the defaults.

This is not super-important since someone can do `array_merge(Qr::getDefaultOptions(), [...])` to achieve the same thing, I just think it's a bit nicer. Feel free to reject ¯\\\_(ツ)\_/¯