### PR TITLE
Check for $options['logo']  to be an array if file already uploaded

### DIFF
--- a/src/Facades/Qr.php
+++ b/src/Facades/Qr.php
@@ -312,8 +312,8 @@ class Qr extends Facade
         }
 
         if (optional($options)['logo']) {
-            reset($options['logo']);
-            $logo = current($options['logo']);
+            
+            $logo = $options['logo'];
 
             if ($logo instanceof UploadedFile && filled($logo->getPathName())) {
                 $maker = $maker->merge($logo->getPathName(), $size, true);
@@ -321,7 +321,7 @@ class Qr extends Facade
                 $disk = optional($options)['uploadOptions']['disk'] ?? 'public';
                 if (Storage::disk($disk)->exists($logo)) {
                     $maker = $maker->merge(
-                        Storage::disk($disk)->url($logo),
+                        Storage::disk($disk)->path($logo),
                         $size,
                         true
                     );

--- a/src/Facades/Qr.php
+++ b/src/Facades/Qr.php
@@ -313,7 +313,12 @@ class Qr extends Facade
 
         if (optional($options)['logo']) {
             
-            $logo = $options['logo'];
+            if(is_array($options['logo'])) {
+                reset($options['logo']);
+                $logo = current($options['logo']);
+            } else {
+                $logo = $options['logo'];
+            }
 
             if ($logo instanceof UploadedFile && filled($logo->getPathName())) {
                 $maker = $maker->merge($logo->getPathName(), $size, true);


### PR DESCRIPTION
Using the Facade in Filament 4.0 with an Action results in the following error:

reset(): Argument [#1](https://github.com/lara-zeus/qr/pull/1) ($array) must be of type array, string given

Investigating the Array reveals $options['logo'] to be a string of the temporary uploaded file after uplaoding, so the array reset is not correct.

Also replaced Storage::disk($disk)->url($logo) for Storage::disk($disk)->path($logo) 
since this also leads to a file not found error.